### PR TITLE
fix: add sass-embedded in project

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "sass-embedded": "^1.83.4",
     "vitepress": "^1.5.0"
   }
 }


### PR DESCRIPTION
### 📚 Description

Fix the error encountered during the installation of node modules

```
[plugin:vite:css] Preprocessor dependency "sass-embedded" not found. Did you install it? Try `pnpm add -D sass-embedded`.
```

This PR adds sass-embedded as a development dependency to resolve the above error.